### PR TITLE
freetype-gl dependency version fixed

### DIFF
--- a/cmake/FetchFreetypeGL.cmake
+++ b/cmake/FetchFreetypeGL.cmake
@@ -2,7 +2,8 @@ include(FetchContent)
 include(CMakeParseArguments)
 
 function(fetch_freetype_gl)
-	cmake_parse_arguments(OPST "" "VERSION" "")
+	cmake_parse_arguments(OPTS "" "VERSION" "" ${ARGN})
+	message(STATUS "Fetching freetype-gl version: ${OPTS_VERSION}")
 	FetchContent_Declare(freetype-gl
 	                     GIT_REPOSITORY https://github.com/rougier/freetype-gl
 	                     GIT_TAG        ${OPTS_VERSION}


### PR DESCRIPTION
freetype-gl cmake build omitted the package version, which caused the failure of the artemis build since the latest freetype-gl is not compatible with the one used in artemis.